### PR TITLE
feat: add gh-scoped-creds

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -7,6 +7,7 @@ dependencies:
   - jupyter-vscode-proxy
   - jupyter-server-proxy
   - nbgitpuller
+  - gh-scoped-creds
   - pip
   - pip:
       - strudel-cli


### PR DESCRIPTION
This PR enables gh-scoped-creds. By creating a new GitHub app to handle authentication, this will allow a user/admin to grant push access to a particular set of repositories from the hub. This workflow requires individual users to run through a GitHub authentication flow c.f. https://github.com/yuvipanda/gh-scoped-creds/