### PR TITLE
feat: add credential helpers

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pip
   - pip:
       - strudel-cli
+      - git-credential-helpers

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,6 @@ dependencies:
   - jupyter-vscode-proxy
   - jupyter-server-proxy
   - nbgitpuller
-  - gh-scoped-creds
   - pip
   - pip:
       - strudel-cli


### PR DESCRIPTION
This PR adds git-credential-helpers, which is an alternative mechanism to gh-scoped-creds for obtaining a short-lived token from GitHub to authenticate repository interactions.

Unlike gh-scoped-creds, this approach doesn't require the device flow, and instead relies on a private key. This makes the UX simpler for users. As such, it's _less_ secure to secret exfiltration than gh-scoped-creds, but the GitHub App itself can only access the contents of the repositories in the strudel-workshops organisation. As such, the attack surface is limited to that organisation's repository contents.

It follows that care should be taken in strudel-workshop repositories to avoid setting GitHub Actions secrets that could be exfiltrated by malicious code pushed to the repositories.